### PR TITLE
from modelling underlying phenomena to modelling surface effects

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -251,7 +251,7 @@ function extract_data_sk(csv, current, dest_name) {
         // extract tests
         current[dest_name + '_tests'].push( csv['tests'][column] );
 
-        // push into dest_name array
+        // push into dest_name array - this is later taken as 'infected'
         current[dest_name].push( current[dest_name + '_confirmed'][i] - current[dest_name + '_recovered'][i] - current[dest_name + '_deaths'][i] );
     }
 }

--- a/index.php
+++ b/index.php
@@ -260,7 +260,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // include recovered in the prediction
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings );
@@ -314,7 +314,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // include recovered in the prediction
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_31_10 );
@@ -364,7 +364,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // include recovered in the prediction
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_27_12 );
@@ -414,7 +414,7 @@
         post_funcs,
         population_size['sk'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // include recovered in the prediction
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_1_1_sk );
@@ -487,7 +487,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // include recovered in the prediction
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_05_01 );
@@ -580,7 +580,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        0,                          // include recovered in the prediction
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_13_02 );

--- a/index.php
+++ b/index.php
@@ -260,7 +260,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings );
@@ -314,7 +314,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_31_10 );
@@ -364,7 +364,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_27_12 );
@@ -414,7 +414,7 @@
         post_funcs,
         population_size['sk'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_1_1_sk );
@@ -487,7 +487,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_05_01 );
@@ -571,7 +571,7 @@
         //seed['infected']['cz'],      // the confirmed cases so far
         model_seed,
         JITTER_COUNT,           // jitter count
-        JITTER_AMOUNT/16,        // jitter amount
+        JITTER_AMOUNT/32,        // jitter amount
         'recovered_new',            // recovered distribution
         40,                         // recovered offset - when to start looking into the past for current recoveries
         'linton',               // deaths distribution
@@ -580,7 +580,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
-        0,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
+        1,                          // growth_rate_from_infected (eg. do not subtract recovered and dead twice)
         0                           // debugging
     );
     run_model( model_settings_13_02 );

--- a/index.php
+++ b/index.php
@@ -260,6 +260,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        1,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings );
@@ -313,6 +314,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        1,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings_31_10 );
@@ -362,6 +364,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        1,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings_27_12 );
@@ -411,6 +414,7 @@
         post_funcs,
         population_size['sk'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        1,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings_1_1_sk );
@@ -483,6 +487,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        1,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings_05_01 );
@@ -498,56 +503,57 @@
         PREDICTION_DAY,             // start
         4,                        // steps
         .1,                        // speed / steepness
-        0.01,                        // scale
+        -0.07,                        // scale
     ));
     rate_funcs.push( new rate_func(
         'exp',                      // name
         PREDICTION_DAY+2,             // start
         15,                         // steps
         1.1,                        // speed / steepness
-        -0.08,                        // scale
+        -0.1,                        // scale
     ));
     // 4th Wave - came much sooner than expected
-    var FOURTH_WAVE = PREDICTION_DAY+10; // set to 16.01
+    var FOURTH_WAVE = PREDICTION_DAY+15;    
     rate_funcs.push( new rate_func(
         'lin',                      // name
         FOURTH_WAVE,                // start
         60,                        // steps
         1.2,                        // speed / steepness
-        0.350,                        // scale
+        0.145,                       // scale
     ));
     // 4th Lockdown
     rate_funcs.push( new rate_func(
         'exp',                      // name
-        FOURTH_WAVE+48,             // start (guessing 22.02.2021) in the ned a week later - 01.03.2021
-        20,                         // steps
+        FOURTH_WAVE+46,             // start (guessing 22.02.2021) -- in the end it was a week later - 01.03.2021 
+        24,                         // steps
         1.2,                        // speed / steepness
-        -0.282,                       // scale
+        -0.15,                       // scale
     ));
     // 5th Wave
-    var FIFTH_WAVE = PREDICTION_DAY+70; // set to 04.03
+    var FIFTH_WAVE = FOURTH_WAVE+48+24; // set to 04.04
     rate_funcs.push( new rate_func(
         'lin',                      // name
         FIFTH_WAVE,                // start
         51,                        // steps
         1.2,                        // speed / steepness
-        0.44,                        // scale
+        0.15,                        // scale
     ));
     // 5th Lockdown
     rate_funcs.push( new rate_func(
         'exp',                      // name
         FIFTH_WAVE+31,          // start (guessing 20.02.2021)
-        20,                        // steps
+        24,                        // steps
         1.2,                        // speed / steepness
-        -0.3,                        // scale
+        -0.15,                        // scale
     ));
     // Add some postprocessing
     post_funcs = [];
     post_funcs.push( new post_func(
         'saw',      // this adds a weekly oscilation to the growth rate
         0,          // dow 
-        0.26        // scale
-    )); 
+        0.32,        // scale
+        0.007       // offset
+    ));
     
     // 13.02
     var model_growthrate = {};
@@ -565,7 +571,7 @@
         //seed['infected']['cz'],      // the confirmed cases so far
         model_seed,
         JITTER_COUNT,           // jitter count
-        JITTER_AMOUNT/64,        // jitter amount
+        JITTER_AMOUNT/16,        // jitter amount
         'recovered_new',            // recovered distribution
         40,                         // recovered offset - when to start looking into the past for current recoveries
         'linton',               // deaths distribution
@@ -574,6 +580,7 @@
         post_funcs,
         population_size['cz'],
         1,                          // ratio of reported cases out of real cases (max 1)
+        0,                          // include recovered in the prediction
         0                           // debugging
     );
     run_model( model_settings_13_02 );

--- a/model.js
+++ b/model.js
@@ -446,7 +446,7 @@ function post_func(name, param1, param2, param3) {
 }
 
 // Sort of struct emulation in js - model prameters
-function params(name, model_duration, growth_rate_seed, growth_rate_min, infected_seed, jitter_count, jitter_amount, recovered_func, recovered_offset, dead_func, cfr, rate_funcs, post_funcs = false, population_size, real_to_reported, include_recovered, debug) {
+function params(name, model_duration, growth_rate_seed, growth_rate_min, infected_seed, jitter_count, jitter_amount, recovered_func, recovered_offset, dead_func, cfr, rate_funcs, post_funcs = false, population_size, real_to_reported, growth_rate_from_infected, debug) {
     this.name = name;
     this.model_duration = model_duration;
     this.irs = growth_rate_seed;
@@ -462,7 +462,7 @@ function params(name, model_duration, growth_rate_seed, growth_rate_min, infecte
     this.post_funcs = post_funcs;
     this.population_size = population_size;
     this.reported_ratio = real_to_reported;
-    this.include_recovered = include_recovered;
+    this.growth_rate_from_infected = growth_rate_from_infected; // TODO compare two models - one based on growth rate from confirmed, another one from infected
     this.debug = debug;
 }
 
@@ -617,10 +617,10 @@ function run_model(params) {
                 if (i in params.infected_seed) {
                     total = infected;
                 } else {
-                    if (params.include_recovered) {
-                        total = infected - recovered_daily - deaths_daily;
+                    if (params.growth_rate_from_infected) {
+                        total = infected;
                     } else {
-                        total = infected - deaths_daily;
+                        total = infected - recovered_daily - deaths_daily;
                     }
                 }
                 var total_reported = total / params.reported_ratio;

--- a/model.js
+++ b/model.js
@@ -225,7 +225,7 @@ function saw(dow, scale, offset) {
         break;
     }
     
-    return value;
+    return value + offset;
 }
 
 // old func for compatibility
@@ -442,10 +442,11 @@ function post_func(name, param1, param2, param3) {
     this.name = name;
     this.param1 = param1;
     this.param2 = param2;
+    this.param3 = param3;
 }
 
 // Sort of struct emulation in js - model prameters
-function params(name, model_duration, growth_rate_seed, growth_rate_min, infected_seed, jitter_count, jitter_amount, recovered_func, recovered_offset, dead_func, cfr, rate_funcs, post_funcs = false, population_size, real_to_reported, debug) {
+function params(name, model_duration, growth_rate_seed, growth_rate_min, infected_seed, jitter_count, jitter_amount, recovered_func, recovered_offset, dead_func, cfr, rate_funcs, post_funcs = false, population_size, real_to_reported, include_recovered, debug) {
     this.name = name;
     this.model_duration = model_duration;
     this.irs = growth_rate_seed;
@@ -461,6 +462,7 @@ function params(name, model_duration, growth_rate_seed, growth_rate_min, infecte
     this.post_funcs = post_funcs;
     this.population_size = population_size;
     this.reported_ratio = real_to_reported;
+    this.include_recovered = include_recovered;
     this.debug = debug;
 }
 
@@ -510,11 +512,6 @@ function run_model(params) {
                             new_rate = model[params.name]['growth_rate'][jitter][i-1] + window[rate_func.name]( i-rate_func.start, rate_func.steps, rate_func.speed, rate_func.scale );
                         }
                     }
-                    // post-processing
-                    for (j=0; j<params.post_funcs.length; j++) {
-                        var post_func = params.post_funcs[j];
-                        new_rate += window[post_func.name]( i+post_func.param1, post_func.param2 );
-                    }
                     // add some jitter
                     if (params.jitter_amount > 0) {
                         rnd = 1  + (Math.random()*params.jitter_amount*2) - (params.jitter_amount);
@@ -529,7 +526,26 @@ function run_model(params) {
                 }
             }
         }
-
+        
+        // post-process growth rate
+        for (var i=0; i < params.model_duration; i++) {
+            if (i in params.irs) {
+            } else {
+                var computed_rate = model[params.name]['growth_rate'][jitter][i];
+                // post-processing
+                for (j=0; j<params.post_funcs.length; j++) {
+                    var post_func = params.post_funcs[j];
+                    computed_rate += window[post_func.name]( i+post_func.param1, post_func.param2, post_func.param3 );
+                }
+                // just for logging purposes
+                postprocessed_new_rate = computed_rate;
+                // check if new_rate over allowed min 
+                computed_rate = Math.max( computed_rate, params.growth_rate_min );
+                // add rate into model
+                model[params.name]['growth_rate'][jitter][i] = computed_rate;
+            }
+        }
+        
         // compute the projected
         recovered = 0;
         deaths = 0;
@@ -601,7 +617,11 @@ function run_model(params) {
                 if (i in params.infected_seed) {
                     total = infected;
                 } else {
-                    total = infected - recovered_daily - deaths_daily;
+                    if (params.include_recovered) {
+                        total = infected - recovered_daily - deaths_daily;
+                    } else {
+                        total = infected - deaths_daily;
+                    }
                 }
                 var total_reported = total / params.reported_ratio;
                 if (total > 0) {


### PR DESCRIPTION
- daily growth function is computed based on 'infected' which is the actual daily number of sick people:
   infected = confirmed - recovered - dead
- when modelling future growth rate, its logical not to subtract future recovered and dead from the model twice.